### PR TITLE
Switch ComponentType to HTML fixing formatting

### DIFF
--- a/src/HTML/ContentType/VueContentTypeDefinition.cs
+++ b/src/HTML/ContentType/VueContentTypeDefinition.cs
@@ -10,7 +10,7 @@ namespace VuePack
 
         [Export(typeof(ContentTypeDefinition))]
         [Name(VueContentType)]
-        [BaseDefinition("htmlx")]
+        [BaseDefinition("HTML")]
         public ContentTypeDefinition IVueContentTypeDefinitionContentType { get; set; }
 
         [Export(typeof(FileExtensionToContentTypeDefinition))]


### PR DESCRIPTION
@madskristensen @jramsay (cc @billti)

Apply fix suggested in Issue #2 to switch ContentType to HTML. Confirmed it fixes Javascript formatting (bracket indentation and highlighting bracket pairs) within Vue SingleFileComponents. Don't see anything broken to date...